### PR TITLE
Bugfix - draw

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,13 +72,13 @@ function calculateWinner(squares) {
     [2, 4, 6]
   ];
   for(let i = 0; i < lines.length; i++) {
-    let isWinner = null;
     const[a, b, c] = lines[i];
     if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a];
-    } else if(!isWinner && squares.every(square => square !== null)) {
-      return "draw";
     }
+  }
+  if(squares.every(square => square !== null)) {
+    return "draw";
   }
   return null;
 }


### PR DESCRIPTION
I fixed a bug where, when a player won in the last round (all the squares were filled), it was counted as a draw even when the player should have won.

The reason for this was that in calculateWinner(), in the for loop, there was an if statement for a draw. So it could determine a draw before reaching the correct "line" in the for loop.

I just simply moved the if statement outside the for loop, and everything seems to work now.
(Also, I removed the isWinner variable, because it was useless.)